### PR TITLE
Ajout de la page /game-dev/asset

### DIFF
--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -1,5 +1,11 @@
 # game-dev
 
+# Tag
+[HDRI]: #Tag
+[Texture]: #Tag
+[Modèle]: #Tag
+[Landscape]: #Tag
+
 ## Asset
 |                  | Lien                           | Meta
 | ---------------- | ------------------------------ | ---
@@ -11,8 +17,3 @@
 | World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
 | Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
 | Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
-
-[HDRI]: tag
-[Texture]: tag
-[Modèle]: tag
-[Landscape]: tag

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -9,9 +9,9 @@
 ## Création d'assets
 |                  | Lien                                         | Meta   
 | ---------------- | -------------------------------------------- | ---
-| World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
-| Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
 | Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
+| Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
+| World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
 
 [HDRI]: #game-dev
 [Landscape]: #game-dev

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -14,6 +14,6 @@
 | Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
 
 [HDRI]: #game-dev
-[Texture]: #game-dev
-[Modèle]: #game-dev
 [Landscape]: #game-dev
+[Modèle]: #game-dev
+[Texture]: #game-dev

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -1,10 +1,9 @@
 # game-dev
 
-# Tag
-[HDRI]: #Tag
-[Texture]: #Tag
-[Modèle]: #Tag
-[Landscape]: #Tag
+[HDRI]: #game-dev
+[Texture]: #game-dev
+[Modèle]: #game-dev
+[Landscape]: #game-dev
 
 ## Asset
 |                  | Lien                           | Meta

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -2,16 +2,16 @@
 **Tags:** [HDRI] | [Landscape] | [Modèle] | [Texture]
 
 ## Asset
-|                  | Lien                           | Meta
-| ---------------- | ------------------------------ | ---
-| Polyhaven        | [Link](https://polyhaven.com/) | [HDRI] / [Modèle] / [Texture]
+|                   | Licence          | Prix             | Lien                           | Meta
+| ----------------- | ---------------- | ---------------- | ------------------------------ | ---
+| **Polyhaven**     | CC0              | Gratuit          | [Lien](https://polyhaven.com/) | [HDRI] / [Modèle] / [Texture]
 
 ## Création d'assets
-|                  | Lien                                         | Meta   
-| ---------------- | -------------------------------------------- | ---
-| Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
-| Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
-| World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
+|                   | Licence          | Prix             | Lien                                         | Meta   
+| ----------------- | ---------------- | ---------------- | -------------------------------------------- | ---
+| **Quixel mixer**  | -                | Gratuit          | [Lien](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
+| **Spacescape**    | -                | Gratuit          | [Lien](http://alexcpeterson.com/spacescape/) | Cubemap spatial
+| **World creator** | -                | Payant (3 Tiers) | [Lien](https://www.world-creator.com/)       | [Landscape]
 
 [HDRI]: #game-dev
 [Landscape]: #game-dev

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -1,9 +1,5 @@
 # game-dev
-
-[HDRI]: #game-dev
-[Texture]: #game-dev
-[Modèle]: #game-dev
-[Landscape]: #game-dev
+**Tags:** [HDRI] | [Texture] | [Modèle] | [Landscape]
 
 ## Asset
 |                  | Lien                           | Meta
@@ -16,3 +12,8 @@
 | World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
 | Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
 | Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
+
+[HDRI]: #game-dev
+[Texture]: #game-dev
+[Modèle]: #game-dev
+[Landscape]: #game-dev

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -4,7 +4,7 @@
 ## Asset
 |                  | Lien                           | Meta
 | ---------------- | ------------------------------ | ---
-| Polyhaven        | [Link](https://polyhaven.com/) | [HDRI] / [Texture] / [Modèle]
+| Polyhaven        | [Link](https://polyhaven.com/) | [HDRI] / [Modèle] / [Texture]
 
 ## Création d'assets
 |                  | Lien                                         | Meta   

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -1,0 +1,18 @@
+# game-dev
+
+## Asset
+|                  | Lien                           | Meta
+| ---------------- | ------------------------------ | ---
+| Polyhaven        | [Link](https://polyhaven.com/) | [HDRI] / [Texture] / [Modèle]
+
+## Création d'assets
+|                  | Lien                                         | Meta   
+| ---------------- | -------------------------------------------- | ---
+| World creator    | [Link](https://www.world-creator.com/)       | [Landscape]
+| Spacescape       | [Link](http://alexcpeterson.com/spacescape/) | Cubemap spatial
+| Quixel mixer     | [Link](https://quixel.com/mixer)             | Permet de fusionner des [Texture]
+
+[HDRI]: tag
+[Texture]: tag
+[Modèle]: tag
+[Landscape]: tag

--- a/game-dev/asset.md
+++ b/game-dev/asset.md
@@ -1,5 +1,5 @@
 # game-dev
-**Tags:** [HDRI] | [Texture] | [Modèle] | [Landscape]
+**Tags:** [HDRI] | [Landscape] | [Modèle] | [Texture]
 
 ## Asset
 |                  | Lien                           | Meta


### PR DESCRIPTION
L'idée serait d'avoir plusieurs format en fonction des pages de ressources, et des tags en fin de fichier, pour que les gens qui veulent en ajouter puisse se référencer aux tags existants, ce qui permet quand on cherche quelque chose de faire une recherche dans la page et de tomber sur ce qu'on cherche directement.
Par contre je sais pas trop vers quoi on pourrait faire pointer les tags, ptet faire un tag.md à part mais ça risque d'être galère à gérer, ou alors ajouer un #tag dans la page en haut ou en bas.
