### PR TITLE
meta: file indexer utility

### DIFF
--- a/game-dev/index.md
+++ b/game-dev/index.md
@@ -1,0 +1,5 @@
+## Index
+
+### 2021
+
+* [Ressources pour game-dev](/game-dev/ressources.md) <kbd>[game-dev](/game-dev)</kbd>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,8 @@
+## Index
+
+### 2021
+
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Ressources pour game-dev](/game-dev/ressources.md) <kbd>[game-dev](/game-dev)</kbd>
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>

--- a/index.py
+++ b/index.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+"""
+Utility to rewrite all index.md files with the list of markdown articles
+discovered on disk. If an index.md file exist already, this utility
+conserve all lines prior to an "## Index" title (or the whole file if
+that title is missing).
+"""
+
+import dataclasses
+import itertools
+import subprocess as sp
+from collections import defaultdict
+from contextlib import suppress
+from datetime import datetime
+from functools import partial
+from operator import attrgetter
+from os import getenv
+from pathlib import Path
+from typing import List
+
+
+ROOT = Path(__file__).parent.resolve()
+GIT_PATH = getenv('GIT_PATH', '/usr/bin/git')
+SKIP_FILES = {'index.md', 'README.md'}
+
+
+def Tree():
+    return defaultdict(Tree)
+
+
+@dataclasses.dataclass
+class Article:
+    title: str
+    write_date: datetime
+    create_date: datetime
+    authors: List[str] = dataclasses.field(default_factory=list)
+    paths: List[Path] = dataclasses.field(default_factory=list)
+
+    @property
+    def name(self):
+        return self.paths[0].name
+
+    @property
+    def paths_parts(self):
+        # [/srv/git/Not-a-hub/langages/cpp/foo.md]
+        # => [["langages", "cpp"]]
+        return [path.parts[len(ROOT.parts):-1] for path in self.paths]
+
+    @property
+    def uris(self):
+        # [/srv/git/Not-a-hub/langages/cpp/foo.md]
+        # => ["/langages/cpp/foo.md"]]
+        return [str(path)[len(str(ROOT)):] for path in self.paths]
+
+    @property
+    def tags(self):
+        # [/srv/git/Not-a-hub/langages/cpp/foo.md]
+        # => {('langages', '/langages'), ('cpp', '/langages/cpp')}
+
+        def addsep(uri, part):
+            return f'{uri}/{part}'
+
+        to_uri = partial(itertools.accumulate, func=addsep)
+
+        return list(sorted({
+            (part, f'/{uri}')
+            for parts in self.paths_parts
+            for part, uri in zip(parts, to_uri(parts))
+        }))
+
+    def uri_for_root(self, root):
+        """
+        From all the paths of the current file, return one that starts
+        with ``root``.
+        """
+        return next(uri for uri in self.uris if uri.startswith(root))
+
+
+def extract_title(path):
+    """ Extract the first top level title of a markdown document """
+    assert path.suffix == '.md'
+
+    with open(path) as fd:
+        # lookahead the next line of every line during iteration
+        it1, it2 = itertools.tee(fd)
+        with suppress(StopIteration):
+            next(it2)
+        for current_line, next_line in itertools.zip_longest(it1, it2):
+            # ATX title style
+            if current_line.startswith('# '):
+                return current_line.strip('# \n')
+            # Setext title style
+            if next_line and all(char == '=' for char in next_line):
+                return current_line.strip()
+
+    return None
+
+
+def extract_git_metadata(path):
+    """
+    Extract the file last write date, the file creation date and the
+    authors of a file using it's git metadata
+    """
+
+    # Get newest commit date as timestamp
+    cmd = [GIT_PATH, 'log', '--follow', '-1', r'--pretty=format:%at', str(path)]
+    proc = sp.run(cmd, capture_output=True, check=True)
+    write_date = datetime.fromtimestamp(int(proc.stdout.strip()))
+
+    # Get oldest commit date as timestamp
+    # command does not work
+    #cmd = [GIT_PATH, 'log', '--follow', '--reversed', '-1', r'--pretty=format:%at', str(path)]
+    #proc = sp.run(cmd, capture_output=True, check=True)
+    #create_date = datetime.fromtimestamp(int(proc.stdout.strip()))
+    create_date = write_date
+
+    # Get the authors from all the "add" and "edit" type commits
+    cmd = [GIT_PATH, 'log', '--follow', '--grep', r'^\(add\|edit\):', '--pretty=full', str(path)]
+    proc = sp.run(cmd, capture_output=True, check=True)
+    authors = {  # extract "John" from "Author: John <john@example.com>"
+        line.partition(b': ')[2].partition(b' <')[0].strip()
+        for line in proc.stdout.splitlines()
+        if line.lower().startswith(b'author: ')
+           or line.lower().startswith(b'    co-authored-by: ')
+    }
+
+    return write_date, create_date, authors
+
+
+def discover_articles(root):
+    """ Discover all articles under ``root``. """
+
+    articles = {}
+    for path in root.glob('**/*.md'):
+        if path.name in SKIP_FILES:
+            continue
+
+        if path.name not in articles:
+            title = extract_title(path) or path.name
+            write_date, create_date, authors = extract_git_metadata(path)
+            articles[path.name] = Article(title, write_date, create_date, authors)
+        articles[path.name].paths.append(path)
+
+    return list(articles.values())
+
+
+def create_index(articles):
+    """
+    Populate an index, a filesystem-like structure where directories are
+    dictionnaries and where file are articles, with all the articles.
+    """
+
+    index = Tree()
+    for article in articles:
+        for parts in article.paths_parts:
+            # /srv/git/Not-a-Hub/langages/cpp/foo.md
+            # index["langages"]["cpp"]["foo.md"] = article
+            subindex = index
+            for part in parts:
+                subindex = subindex[part]
+            subindex[article.name] = article
+
+    return index
+
+
+def walk(dir_, index, *, rewrite=False):
+    """ Recursively get all articles published under this index """
+    articles = []
+
+    for name, article_or_index in index.items():
+        if isinstance(article_or_index, Article):
+            article = article_or_index
+            articles.append(article)
+        else:
+            subindex = article_or_index
+            articles.extend(walk(f'{dir_}{name}/', subindex, rewrite=rewrite))
+
+    if rewrite:
+        rewrite_index_file(dir_, articles)
+
+    return articles
+
+
+def rewrite_index_file(dir_, articles):
+    """
+    Rewrite the index file, conserve what's before the "## Index" title
+    or the whole file it this title is missing then write the index
+    using the following format:
+
+    ## Index
+
+    ### 2021
+
+    * [Article feb](/tag1/tag2/article-4.md) <kbd>[tag1](/tag1)</kbd> <kbd>[tag2](/tag1/tag2)</kbd>
+    * [Article jan](/tag1/tag2/article-3.md) <kbd>[tag1](/tag1)</kbd> <kbd>[tag2](/tag1/tag2)</kbd>
+
+    ### 2020
+
+    * [Article dec-2](/tag1/article-2.md) <kbd>[tag1](/tag1)</kbd>
+    * [Article dec-1](/tag1/article-1.md) <kbd>[tag1](/tag1)</kbd>
+    """
+
+    index_path = ROOT.joinpath(f'{dir_}index.md'.lstrip('/'))
+
+    # Sort and group the articles by date
+    articles.sort(key=attrgetter('create_date'), reverse=True)
+    articles_per_year = itertools.groupby(articles, attrgetter('create_date.year'))
+
+    # Conserve what exist before the generated index
+    # mode 'a', seek(0) to create the file if it does not exist
+    with open(index_path, 'a+b') as index_file:
+        index_file.seek(0)
+        index_pos = 0
+        while True:
+            line = index_file.readline()
+            if line in (b'', b'## Index\n'):
+                break
+            index_pos += len(line)
+        index_file.seek(index_pos)
+        index_file.truncate()
+
+    # Write the index
+    with open(index_path, 'a') as index_file:
+        index_file.write("## Index\n")
+        for year, articles in articles_per_year:
+            index_file.write(f"\n### {year}\n\n")
+            index_file.write(''.join(
+                "* [{title}]({uri}) {tags}\n".format(
+                    title=article.title,
+                    uri=article.uri_for_root(f'/{dir_}'.rstrip('/')),
+                    tags=' '.join(
+                        f"<kbd>[{tag}]({uri})</kbd>"
+                        for tag, uri in article.tags
+                    )
+                )
+                for article in articles
+            ))
+
+
+def main():
+    """ Rewrite all index files """
+    articles = discover_articles(ROOT)
+    index = create_index(articles)
+    walk('', index, rewrite=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/langages/index.md
+++ b/langages/index.md
@@ -1,0 +1,7 @@
+## Index
+
+### 2021
+
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>

--- a/langages/python/apprendre-python-quoi-lire-quoi-regarder.md
+++ b/langages/python/apprendre-python-quoi-lire-quoi-regarder.md
@@ -1,14 +1,14 @@
 # Apprendre Python, quoi lire, quoi regarder
 
-La documentation officielle, votre principale source de connaissance (aussi disponible en français) : https://docs.python.org
+La documentation officielle, votre principale source de connaissance (aussi disponible en français) : <https://docs.python.org>
 
 Parmi la documentation, voici quelques pages que nous jugeons essentielles à lire :
 
-* https://docs.python.org/library/functions.html
-* https://docs.python.org/library/stdtypes.html
-* https://docs.python.org/library/string.html
-* https://docs.python.org/library/exceptions.html
-* https://docs.python.org/reference/datamodel.html
+* <https://docs.python.org/library/functions.html>
+* <https://docs.python.org/library/stdtypes.html>
+* <https://docs.python.org/library/string.html>
+* <https://docs.python.org/library/exceptions.html>
+* <https://docs.python.org/reference/datamodel.html>
 
 ## Cours vidéos
 
@@ -23,7 +23,7 @@ Parmi la documentation, voici quelques pages que nous jugeons essentielles à li
 
 ## Notions avancées
 
-* La philosophie du langage (must read !) : https://www.python.org/dev/peps/pep-0020/
+* La philosophie du langage (must read !) : <https://www.python.org/dev/peps/pep-0020/>
 * Le style de rédaction à privilégier : <https://www.python.org/dev/peps/pep-0008/>
 * Orienté objet : <https://zestedesavoir.com/tutoriels/1253/la-programmation-orientee-objet-en-python/>
 * Classes, dundler, descripteurs et itérateurs : <https://zestedesavoir.com/tutoriels/954/notions-de-python-avancees/>

--- a/langages/python/critique-du-cours-video-sur-python-de-graven.md
+++ b/langages/python/critique-du-cours-video-sur-python-de-graven.md
@@ -1,18 +1,33 @@
 # Critique du cours vidéo sur Python de Graven
 
-Le cours intitulé "Apprendre le Python" est un cours proposé sur la chaîne YouTube Gravenilvectuto. Le cours se présente comme un cours pour apprendre les fondamentaux du langage de programmation Python. Il est constitué de 9 vidéos sur le langage d'une moyenne de 13 minutes et d'une vidéo sur la bibliothèque Tkinter de 40 minutes.
+Le cours intitulé "Apprendre le Python" est un cours proposé sur la chaîne YouTube Gravenilvectuto. Le cours se présente
+comme un cours pour apprendre les fondamentaux du langage de programmation Python. Il est constitué de 9 vidéos sur le
+langage d'une moyenne de 13 minutes et d'une vidéo sur la bibliothèque Tkinter de 40 minutes.
 
-Avant tout chose, je (Julien -Dr Lazor- Castiaux) n'ai aucun grief contre Lorenzo, le vidéaste auteur de ce cours. La qualité visuelle des vidéos est supérieure à ce que l'on trouve d'ordinaire, le rythme est correctement soutenu et les exemples sont bien choisis. Les critiques de ce billet ne portent que sur le coté technique, le code source et les explications.
+Avant tout chose, je (Julien -Dr Lazor- Castiaux) n'ai aucun grief contre Lorenzo, le vidéaste auteur de ce cours. La
+qualité visuelle des vidéos est supérieure à ce que l'on trouve d'ordinaire, le rythme est correctement soutenu et les
+exemples sont bien choisis. Les critiques de ce billet ne portent que sur le coté technique, le code source et les
+explications.
 
 ## Les défauts du cours
 
 ### Épisode 1 - Introduction
 
-Contrairement à ce qui est présenté dans la vidéo, un IDE (environnement de développement intégré) n'est pas *nécessaire* pour développer. Il est d'ailleurs plus commun de croiser des développeurs Python qui utilisent le combo éditeur de texte et terminal du fait de la légèreté du langage. [J'ai écrit un billet à ce sujet](https://docs.drlazor.be/python_ide.md).
+Contrairement à ce qui est présenté dans la vidéo, un IDE (environnement de développement intégré) n'est
+pas *nécessaire* pour développer. Il est d'ailleurs plus commun de croiser des développeurs Python qui utilisent le
+combo éditeur de texte et terminal du fait de la légèreté du langage. [J'ai écrit un billet à ce sujet]
+(https://docs.drlazor.be/python_ide.md).
 
-L'ensemble des vidéos sera capturé dans cet environnement. On peut regretter que le vidéaste ne désactive pas les différents linters et correcteurs orthographiques. Les démonstrations sont sans-cesse interrompues par myriade de pop-up de conseil et les différents mots français sont régulièrement soulignés inutilement par le correcteur orthographique.
+L'ensemble des vidéos sera capturé dans cet environnement. On peut regretter que le vidéaste ne désactive pas les
+différents linters et correcteurs orthographiques. Les démonstrations sont sans-cesse interrompues par myriade de
+pop-up de conseil et les différents mots français sont régulièrement soulignés inutilement par le correcteur
+orthographique.
 
-Lors de l'installation de Python, l'attention du téléspectateur n'est pas attirée sur l'option "Add Python to PATH", il s'agit d'une case à cocher qui rend accessible les programmes `python`, `py` et `pip` via la ligne de commande. Les débutants ne savent généralement pas comment changer les variables d'environnement sur Windows et se plaignent de ne pas réussir à lancer Python car `'python' n’est pas reconnu en tant que commande interne ou externe, un programme exécutable ou un fichier de commandes.`.
+Lors de l'installation de Python, l'attention du téléspectateur n'est pas attirée sur l'option "Add Python to PATH", il
+s'agit d'une case à cocher qui rend accessible les programmes `python`, `py` et `pip` via la ligne de commande. Les
+débutants ne savent généralement pas comment changer les variables d'environnement sur Windows et se plaignent de ne
+pas réussir à lancer Python car `'python' n’est pas reconnu en tant que commande interne ou externe, un programme
+exécutable ou un fichier de commandes.`.
 
 Le tout premier bout de code montré à l'écran est le suivant :
 
@@ -21,7 +36,9 @@ if __name__ == "__main__":
     print("Hello world")
 ```
 
-Si il est commun de voir un `if __name__ == "__main__"` dans les projets Python, il n'est pas nécessaire et ne présente un intérêt qu'au moment où les modules sont introduits. Il aurait été plus judicieux de ne pas l'introduire pour ne pas rajouter de la complexité inutile.
+Si il est commun de voir un `if __name__ == "__main__"` dans les projets Python, il n'est pas nécessaire et ne présente
+un intérêt qu'au moment où les modules sont introduits. Il aurait été plus judicieux de ne pas l'introduire pour ne pas
+rajouter de la complexité inutile.
 
 Le dernier point sera heureusement rectifié dans deux vidéos.
 
@@ -29,51 +46,85 @@ Le dernier point sera heureusement rectifié dans deux vidéos.
 
 L'épisode est bon dans l'ensemble.
 
-Je regrette néanmoins que la fonction `type()` n'ait pas été introduite, elle aurait permis de construire la notion de type autrement que par la coloration syntaxique dans pycharm.
+Je regrette néanmoins que la fonction `type()` n'ait pas été introduite, elle aurait permis de construire la notion de
+type autrement que par la coloration syntaxique dans pycharm.
 
-Je regrette également que la fonction `print` n'ait pas été utilisé correctement. La fonction peut prendre plusieurs arguments qui seront tous castés en string et concaténés avec un espace. La solution proposée est de passer via le type `str` pour convertir le nombre en chaîne de caractères.
+Je regrette également que la fonction `print` n'ait pas été utilisé correctement. La fonction peut prendre plusieurs
+arguments qui seront tous castés en string et concaténés avec un espace. La solution proposée est de passer via le type
+`str` pour convertir le nombre en chaîne de caractères.
 
-Il aurait été judicieux de présenter ces types plus tôt, à savoir les types `int()`, `str()`, `float()` et `bool()`, et de montrer qu'il peuvent être utilisés pour convertir les types entre eux. Les explications de la conversion en booléen auraient par exemple pu servir de fondation pour l'épisode sur les conditions.
+Il aurait été judicieux de présenter ces types plus tôt, à savoir les types `int()`, `str()`, `float()` et `bool()`, et
+de montrer qu'il peuvent être utilisés pour convertir les types entre eux. Les explications de la conversion en booléen
+auraient par exemple pu servir de fondation pour l'épisode sur les conditions.
 
-La fonction `format` sera présentée dans la vidéo suivante pour faciliter l'insertion de données dans les chaînes de caractères.
+La fonction `format` sera présentée dans la vidéo suivante pour faciliter l'insertion de données dans les chaînes de
+caractères.
 
 ### Épisode 3 - Conditions
 
-Il existe une [syntaxe dédiée](https://www.python.org/dev/peps/pep-0308/) pour les ternaires depuis Python 2.5 (sortie en 2006). La syntaxe est la suivante :
+Il existe une [syntaxe dédiée](https://www.python.org/dev/peps/pep-0308/) pour les ternaires depuis Python 2.5(sortie en
+2006). La syntaxe est la suivante :
 
 ```python
 x = true_value if condition else false_value
 ```
 
-L'exemple d'expression ternaire présenté dans la vidéo, en plus d'être difficile à lire et obsolète, est faux. Le code montré réalise un accès dans un tuple littéral. Cet accès est possible car le tuple possède deux éléments accessibles aux indices 0 et 1 et que les deux valeurs booléenes ont un équivalent entier : 0 pour False, 1 pour True. Il est dit dans la vidéo que le premier élément sera renvoyé si l'expression est vraie, or c'est le second qui sera renvoyé.
+L'exemple d'expression ternaire présenté dans la vidéo, en plus d'être difficile à lire et obsolète, est faux. Le code
+montré réalise un accès dans un tuple littéral. Cet accès est possible car le tuple possède deux éléments accessibles
+aux indices 0 et 1 et que les deux valeurs booléenes ont un équivalent entier : 0 pour False, 1 pour True. Il est dit
+dans la vidéo que le premier élément sera renvoyé si l'expression est vraie, or c'est le second qui sera renvoyé.
 
 ### Épisode 4 - Listes
 
-Si l'ensemble des opérations présentées sur les listes sont correctes, l'attention quant à la complexité de ces opérations n'est pas attiré. Bon nombre d'opérations (`del`, `insert`, `remove`) sont en complexité linéaire et non pas constante. Utiliser ces opérations doit donc se faire avec parcimonie.
+Si l'ensemble des opérations présentées sur les listes sont correctes, l'attention quant à la complexité de ces
+opérations n'est pas attiré. Bon nombre d'opérations (`del`, `insert`, `remove`) sont en complexité linéaire et non pas
+constante. Utiliser ces opérations doit donc se faire avec parcimonie.
 
-Pour récupérer le dernier élément d'une liste, la syntaxe `len(online_players) - 1` est présentée. Cette syntaxe, bien que correcte, est inutilement verbeuse. Python est en fait capable de directement indexer en partant de la fin en fournissant un indice négatif.
+Pour récupérer le dernier élément d'une liste, la syntaxe `len(online_players) - 1` est présentée. Cette syntaxe, bien
+que correcte, est inutilement verbeuse. Python est en fait capable de directement indexer en partant de la fin en
+fournissant un indice négatif.
 
-La vidéo présente la bibliothèque `statistics` pour calculer la moyenne d'une liste. Cette opération est en fait facilement réalisable au moyen des fonctions `sum` et `len`.
+La vidéo présente la bibliothèque `statistics` pour calculer la moyenne d'une liste. Cette opération est en fait
+facilement réalisable au moyen des fonctions `sum` et `len`.
 
-Les listes seront d'ailleurs les seules structures de données présentées dans la vidéo, pas un mot sur les dictionnaires, les sets ou la bibliothèque collections.
+Les listes seront d'ailleurs les seules structures de données présentées dans la vidéo, pas un mot sur les
+dictionnaires, les sets ou la bibliothèque collections.
 
 ### Épisode 5 - Boucles
 
-Le `for` traditionnellement utilisé dans les langages comme C, Java (`for (int x = 0; x < 5; x++)`) n'existe pas en Python. Python n'est capable d'itérer que sur des objets itérables (ceux qui définissent les méthodes magiques `__iter__` ou/et `__next__`). `range` est un de ces objets, bien qu'à l'utilisation il permet de simuler le `for` classique, il n'en reste pas moins un objet qui implémente ces deux méthodes.
+Le `for` traditionnellement utilisé dans les langages comme C, Java (`for (int x = 0; x < 5; x++)`) n'existe pas en
+Python. Python n'est capable d'itérer que sur des objets itérables (ceux qui définissent les méthodes magiques
+`__iter__` ou/et `__next__`). `range` est un de ces objets, bien qu'à l'utilisation il permet de simuler le `for`
+classique, il n'en reste pas moins un objet qui implémente ces deux méthodes.
 
 ### Épisode 6 - Fonctions
 
-Tout de suite après avoir montré comment définir et appeler des fonctions, l'auteur introduit les variables globales. Les variables globales font partie des techniques appelées de *mémoire partagée*, un ensemble de la mémoire qui est accessible et qui peut être modifié par plusieurs entités à la fois, ici les fonctions. Ces techniques sont connues pour mener à des programmes qui sont difficiles à maintenir, qui présentent plus de bug et qui empêchent l'exécution parallèle. Il est dangereux d'introduire ce mécanisme et on lui préférera systématiquement les fonctions paramétriques.
+Tout de suite après avoir montré comment définir et appeler des fonctions, l'auteur introduit les variables globales.
+Les variables globales font partie des techniques appelées de *mémoire partagée*, un ensemble de la mémoire qui est
+accessible et qui peut être modifié par plusieurs entités à la fois, ici les fonctions. Ces techniques sont connues
+pour mener à des programmes qui sont difficiles à maintenir, qui présentent plus de bug et qui empêchent l'exécution
+parallèle. Il est dangereux d'introduire ce mécanisme et on lui préférera systématiquement les fonctions
+paramétriques.
 
-En programmation orientée objet, lorsqu'une fonction nécessite un contexte pour fonctionner, on préférera utiliser un objet pour sauvegarder ce contexte et écrire une *méthode*.
+En programmation orientée objet, lorsqu'une fonction nécessite un contexte pour fonctionner, on préférera utiliser un
+objet pour sauvegarder ce contexte et écrire une *méthode*.
 
-L'auteur se trompe lorsqu'il dit qu'il est nécessaire de marquer les variables globales comme globales pour pouvoir y accéder. Il n'y a aucun problème à accéder en *lecture* (affichage, utilisation) aux variables définies dans le contexte global. Ce mot clé n'est nécessaire que lorsqu'on *modifie* (affectation) les variables globales.
+L'auteur se trompe lorsqu'il dit qu'il est nécessaire de marquer les variables globales comme globales pour pouvoir y
+accéder. Il n'y a aucun problème à accéder en *lecture* (affichage, utilisation) aux variables définies dans le
+contexte global. Ce mot clé n'est nécessaire que lorsqu'on *modifie* (affectation) les variables globales.
 
 ### Épisode 7 - Objets
 
-La vidéo est d'une très grande qualité visuelle, les animations sont réussies, les exemples sont bien choisis et le tout est correctement dynamique. En bref l'auteur réussi à expliquer le mécanisme de l'orienté objet dans une vidéo de seulement 20 minutes, chapeau l'artiste !
+La vidéo est d'une très grande qualité visuelle, les animations sont réussies, les exemples sont bien choisis et le tout
+est correctement dynamique. En bref l'auteur réussi à expliquer le mécanisme de l'orienté objet dans une vidéo de
+seulement 20 minutes, chapeau l'artiste !
 
-Cependant, les bonnes pratiques de développement Python contrastent avec les bonnes pratiques d'autres langages de programmation orientée-objet comme Java, C# ou PHP. En Python, la notion d'accessibilité des variables n'existe pas, pas de mot clé `public` ou `private` pour définir la visibilité des attributs ou des méthodes. En réalité il s'agit d'un choix d'implémentation, en Python on accédera directement à l'attribut tant en lecture qu'en écriture sans passer par des méthodes `get_xyz()` ou `set_xyz()`. Si exécuter une fonction est nécessaire pour effectuer en traitement avant de renvoyer une valeur, on préférera utiliser une propriété.
+Cependant, les bonnes pratiques de développement Python contrastent avec les bonnes pratiques d'autres langages de
+programmation orientée-objet comme Java, C# ou PHP. En Python, la notion d'accessibilité des variables n'existe pas,
+pas de mot clé `public` ou `private` pour définir la visibilité des attributs ou des méthodes. En réalité il s'agit
+d'un choix d'implémentation, en Python on accédera directement à l'attribut tant en lecture qu'en écriture sans passer
+par des méthodes `get_xyz()` ou `set_xyz()`. Si exécuter une fonction est nécessaire pour effectuer en traitement avant
+de renvoyer une valeur, on préférera utiliser une propriété.
 
 ### Épisodes suivants
 
@@ -83,64 +134,122 @@ Les épisodes 8, 9 et 10 ne présentent pas de problème significatif.
 
 ### Structure de données
 
-Les seules structures de données présentées dans le cours sont les listes et les objets. Python est un langage très riche qui définit une abondance de structures de données qu'il est nécessaire de connaître et de savoir exploiter.
+Les seules structures de données présentées dans le cours sont les listes et les objets. Python est un langage très
+riche qui définit une abondance de structures de données qu'il est nécessaire de connaître et de savoir exploiter.
 
-Un ensemble mathématique est une structure de données où les éléments sont ou ne sont pas présents. D'un point de vue informatique, ils peuvent être considérés comme des listes non-ordonnées sans doublons. Ils sont implémentés en Python via l'objet `set`.
+Un ensemble mathématique est une structure de données où les éléments sont ou ne sont pas présents. D'un point de vue
+informatique, ils peuvent être considérés comme des listes non-ordonnées sans doublons. Ils sont implémentés en Python
+via l'objet `set`.
 
-Un dictionnaire est un livre qui associe chaque mot d'une langue à une définition. Il existe aussi des dictionnaires de traduction où chaque mot d'une langue est associé au même mot dans une autre langue. En informatique, un dictionnaire (aussi appelé tableau associatif ou *map*) est une structure de données qui associe un élément quelconque à un autre élément quelconque. Ils sont implémentés en Python via l'objet `dict`. Les dictionnaires de base ne sont pas forcément triés (avant Python 3.7), leur équivalent trié est implémenté via `collections.OrderedDict`.
+Un dictionnaire est un livre qui associe chaque mot d'une langue à une définition. Il existe aussi des dictionnaires de
+traduction où chaque mot d'une langue est associé au même mot dans une autre langue. En informatique, un dictionnaire
+(aussi appelé tableau associatif ou *map*) est une structure de données qui associe un élément quelconque à un autre
+élément quelconque. Ils sont implémentés en Python via l'objet `dict`. Les dictionnaires de base ne sont pas forcément
+triés (avant Python 3.7), leur équivalent trié est implémenté via `collections.OrderedDict`.
 
-Un multi-ensemble mathématique est un ensemble où les éléments peuvent exister plusieurs fois. En informatique ils sont généralement implémentés comme un dictionnaire qui associe chaque élément au nombre de fois où il existe. En Python ils sont implémentés via `collections.Counter`.
+Un multi-ensemble mathématique est un ensemble où les éléments peuvent exister plusieurs fois. En informatique ils sont
+généralement implémentés comme un dictionnaire qui associe chaque élément au nombre de fois où il existe. En Python ils
+sont implémentés via `collections.Counter`.
 
-Une file ou une queue comme une file à la caisse est une autre structure de données où on ajoute des éléments d'un côté et où on retire les éléments depuis l'autre côté. Si ces opérations sont possible sur des listes classiques, ces opérations sont néanmoins non-optimisées. La structure optimisée pour gérer des files existe via l'objet `collections.deque`.
+Une file ou une queue comme une file à la caisse est une autre structure de données où on ajoute des éléments d'un côté
+et où on retire les éléments depuis l'autre côté. Si ces opérations sont possible sur des listes classiques, ces
+opérations sont néanmoins non-optimisées. La structure optimisée pour gérer des files existe via l'objet
+`collections.deque`.
 
-Les bibliothèques `collections`, `queue`, `bisect` et `heapq` regorgent d'autres structures de données qui ne sont pas reprises ici.
+Les bibliothèques `collections`, `queue`, `bisect` et `heapq` regorgent d'autres structures de données qui ne sont pas
+reprises ici.
 
 ### Scope Python et variables globales
 
-Ce qu'on appelle le *scope* est le niveau d'accessibilité des variables, c'est-à-dire quand et comment les variables du programme sont accessibles.
+Ce qu'on appelle le *scope* est le niveau d'accessibilité des variables, c'est-à-dire quand et comment les variables du
+programme sont accessibles.
 
-Lorsque Python tente d'accéder à une variable *en lecture*, il va consulter le scope de la fonction : il commence par consulter les variables locales à la fonction. S'il ne la trouve pas, il va consulter le scope de la fonction supérieure et ainsi de suite jusqu'à arriver au scope dit *global* qui correspond à la racine du module. Si la variable n'a été trouvée dans aucun scope, une erreur `NameError` sera remontée à l'utilisateur.
+Lorsque Python tente d'accéder à une variable *en lecture*, il va consulter le scope de la fonction : il commence par
+consulter les variables locales à la fonction. S'il ne la trouve pas, il va consulter le scope de la fonction
+supérieure et ainsi de suite jusqu'à arriver au scope dit *global* qui correspond à la racine du module. Si la variable
+n'a été trouvée dans aucun scope, une erreur `NameError` sera remontée à l'utilisateur.
 
-Lorsque Python tente d'accéder à une variable *en écriture*, il ne consulte *que* les variables locales, si la variable n'existe pas elle sera créée dans les variables locales *même si* elle existait dans un scope supérieur. Pour pouvoir modifier une variable d'un scope supérieur il est nécessaire d'utiliser les mots clés `global` ou `nonlocal`.
+Lorsque Python tente d'accéder à une variable *en écriture*, il ne consulte *que* les variables locales, si la variable
+n'existe pas elle sera créée dans les variables locales *même si* elle existait dans un scope supérieur. Pour pouvoir
+modifier une variable d'un scope supérieur il est nécessaire d'utiliser les mots clés `global` ou `nonlocal`.
 
-Si ce comportement est celui par défaut c'est qu'il est déconseillé de modifier les variables définies en dehors de sa propre fonction. En effet, pour un programme conséquent, il devient difficile de déterminer quels sont les fonctions qui modifient une variable, le développeur n'a pas d'autre solution que de scanner l'ensemble du programme pour déterminer quelle fonction lit / écrit cette variable ce qui pose des problèmes quant à la compréhension du programme en général.
+Si ce comportement est celui par défaut c'est qu'il est déconseillé de modifier les variables définies en dehors de sa
+propre fonction. En effet, pour un programme conséquent, il devient difficile de déterminer quels sont les fonctions
+qui modifient une variable, le développeur n'a pas d'autre solution que de scanner l'ensemble du programme pour
+déterminer quelle fonction lit / écrit cette variable ce qui pose des problèmes quant à la compréhension du programme
+en général.
 
-Un autre problème survient lorsqu'on souhaite paralléliser un traitement sur plusieurs processeurs. Si un processeur lit le contenu d'une variable globale en même temps qu'un autre processeur en change son contenu, on se retrouve dans une situation où *l'on ne sait pas* ce qui a été lu. La lecture a-t-elle eu lieu avant la modification ? Après ? Ou pire... Pendant ?
+Un autre problème survient lorsqu'on souhaite paralléliser un traitement sur plusieurs processeurs. Si un processeur lit
+le contenu d'une variable globale en même temps qu'un autre processeur en change son contenu, on se retrouve dans une
+situation où *l'on ne sait pas* ce qui a été lu. La lecture a-t-elle eu lieu avant la modification ? Après ? Ou pire...
+Pendant ?
 
-Ces problèmes ne se produisent pas lorsqu'on utilise une stratégie d'implémentation claire ou l'utilisation des variables est clairement définie comme pour les fonctions paramétriques ou les objets.
+Ces problèmes ne se produisent pas lorsqu'on utilise une stratégie d'implémentation claire ou l'utilisation des
+variables est clairement définie comme pour les fonctions paramétriques ou les objets.
 
 ### Visibilité des attributs et des méthodes
 
-La visibilité en orienté objet est une notion qui permet de contrôler *qui* a accès (en lecture, en écriture ou en exécution) aux attributs et aux méthodes d'un objet. Cette notion est implémentée dans nombre de langages orientés objet statiques comme Java, C# et C++. Lorsqu'un attribut est déclaré avec `private` elle n'est accessible que par l'objet courant, il en va de même pour les méthodes. Au contraire lorsqu'un attribut/une méthode est déclaré public, tout le monde peut y accéder.
+La visibilité en orienté objet est une notion qui permet de contrôler *qui* a accès (en lecture, en écriture ou en
+exécution) aux attributs et aux méthodes d'un objet. Cette notion est implémentée dans nombre de langages orientés
+objet statiques comme Java, C# et C++. Lorsqu'un attribut est déclaré avec `private` elle n'est accessible que par
+l'objet courant, il en va de même pour les méthodes. Au contraire lorsqu'un attribut/une méthode est déclaré public,
+tout le monde peut y accéder.
 
-Cette notion de visibilité est absente de Python qui préfère *faire confiance aux développeurs* qu'ils n'aillent pas toucher ce qu'ils ne devraient pas. Ainsi la seule notion qui sépare les attributs, propriétés et méthodes publiques de celles considérées comme "privées" est une convention d'écriture. On préfixera ce qui est privé par un underscore. Le développeur est libre de n'en faire qu'à sa tête de tout de même les utiliser même si c'est déconseillé.
+Cette notion de visibilité est absente de Python qui préfère *faire confiance aux développeurs* qu'ils n'aillent pas
+toucher ce qu'ils ne devraient pas. Ainsi la seule notion qui sépare les attributs, propriétés et méthodes publiques de
+celles considérées comme "privées" est une convention d'écriture. On préfixera ce qui est privé par un underscore. Le
+développeur est libre de n'en faire qu'à sa tête de tout de même les utiliser même si c'est déconseillé.
 
-Dans l'industrie il n'y a au final pas de problème à ce que le langage ne définisse pas lui-même de niveau de visibilité. Une équipe constituée de développeurs compétents, que ce soit en Python ou dans un autre langage, est capable de faire la part des choses. Il s'avère même parfois de meilleur goût de ne pas respecter cette convention de visibilité et de tout de même utiliser une variable / méthode "privée".
+Dans l'industrie il n'y a au final pas de problème à ce que le langage ne définisse pas lui-même de niveau de
+visibilité. Une équipe constituée de développeurs compétents, que ce soit en Python ou dans un autre langage, est
+capable de faire la part des choses. Il s'avère même parfois de meilleur goût de ne pas respecter cette convention de
+visibilité et de tout de même utiliser une variable / méthode "privée".
 
 ### Accesseurs et mutateurs
 
-Dans la même lignée qu'il n'y a pas de notion de visibilité en Python, les pratiques de développement Python conseillent de directement modifier les attributs des objets sans passer par des méthodes de contrôle. Dit autrement, l'utilisation systématique d'accesseurs (*getters*) et de mutateurs (*setters*) est déconseillé.
+Dans la même lignée qu'il n'y a pas de notion de visibilité en Python, les pratiques de développement Python conseillent
+de directement modifier les attributs des objets sans passer par des méthodes de contrôle. Dit autrement, l'utilisation
+systématique d'accesseurs (*getters*) et de mutateurs (*setters*) est déconseillé.
 
-Dans l'industrie ceci ne pose en réalité aucun souci, les développeurs qui définissent les interfaces objets sont généralement ceux qui les utiliseront ou qui seront chargés de relire le code des autres développeurs.
+Dans l'industrie ceci ne pose en réalité aucun souci, les développeurs qui définissent les interfaces objets sont
+généralement ceux qui les utiliseront ou qui seront chargés de relire le code des autres développeurs.
 
-Cependant, il est parfois nécessaire d'effectuer des traitements à l'accès ou à la modification des attributs. Pour ce faire, Python a opté pour les propriétés. Une propriété s'utilise comme une variable normale, on récupère la valeur en donnant uniquement le nom de la propriété et on modifie sa valeur comme une simple affectation. La différence est qu'au lieu d'être directement accédée ou modifiée, c'est une fonction de traitement qui sera chargée de renvoyer / modifier la variable.
+Cependant, il est parfois nécessaire d'effectuer des traitements à l'accès ou à la modification des attributs. Pour ce
+faire, Python a opté pour les propriétés. Une propriété s'utilise comme une variable normale, on récupère la valeur en
+donnant uniquement le nom de la propriété et on modifie sa valeur comme une simple affectation. La différence est qu'au
+lieu d'être directement accédée ou modifiée, c'est une fonction de traitement qui sera chargée de renvoyer / modifier
+la variable.
 
-Via ce mécanisme, il est possible de laisser un attribut "public" (sans underscore en préfixe) et s'il s'avère à l'utilisation qu'une fonction de traitement est nécessaire, il suffit de préfixer l'attribut pour qu'il soit "privé" et de définir au niveau de la classe une propriété du même nom que l'ancien attribut public. Le code qui exploitait l'attribut exploite maintenant la propriété indifféremment.
+Via ce mécanisme, il est possible de laisser un attribut "public" (sans underscore en préfixe) et s'il s'avère à
+l'utilisation qu'une fonction de traitement est nécessaire, il suffit de préfixer l'attribut pour qu'il soit "privé" et
+de définir au niveau de la classe une propriété du même nom que l'ancien attribut public. Le code qui exploitait
+l'attribut exploite maintenant la propriété indifféremment.
 
 ### Cours de Java... en Python...
 
-Si la qualité visuelle des vidéos et la dynamique du cours sont supérieures à bon nombre de cours en ligne (gratuit et payant), le côté technique est quant à lui approximatif. L'approche pédagogique de l'auteur souffre de nombreux biais qui sont communs aux développeurs Java qui s'essaient au langage Python.
+Si la qualité visuelle des vidéos et la dynamique du cours sont supérieures à bon nombre de cours en ligne (gratuit et
+payant), le côté technique est quant à lui approximatif. L'approche pédagogique de l'auteur souffre de nombreux biais
+qui sont communs aux développeurs Java qui s'essaient au langage Python.
 
 Plusieurs arguments penchent en cette faveur :
 
 * Il est commun d'utiliser un IDE complet pour développer en Java, pas en Python ;
-* Il y a conversion automatique des entiers vers les chaînes de caractère en Java, en Python elles doivent être explicites ;
-* L'expression `condition ? true_value : false_value` est une expression ternaire en Java, l'expression Python `(false_value, true_value)[condition]` y ressemble fâcheusement (expressions finales d'un côté, condition de l'autre) mais n'est pas une expression ternaire en Python ;
-* Le *for* classique n'existe pas en Python, il est simulé par l'objet `range` mais il n'existe bien en Python que ce que les développeurs Java appellent le *for each* ;
-* Les bonnes pratiques Java dictent qu'il est important de définir des méthodes dédiées (*getters* et *setters*) pour manipuler les attributs d'un objet, les bonnes pratiques Python dictent de modifier directement l'attribut ou de passer par des propriétés.
+* Il y a conversion automatique des entiers vers les chaînes de caractère en Java, en Python elles doivent être
+  explicites ;
+* L'expression `condition ? true_value : false_value` est une expression ternaire en Java, l'expression Python `
+  (false_value, true_value)[condition]` y ressemble fâcheusement (expressions finales d'un côté, condition de l'autre)
+  mais n'est pas une expression ternaire en Python ;
+* Le *for* classique n'existe pas en Python, il est simulé par l'objet `range` mais il n'existe bien en Python que ce
+  que les développeurs Java appellent le *for each* ;
+* Les bonnes pratiques Java dictent qu'il est important de définir des méthodes dédiées (*getters* et *setters*) pour
+  manipuler les attributs d'un objet, les bonnes pratiques Python dictent de modifier directement l'attribut ou de
+  passer par des propriétés.
 
 ## Conclusion
 
-Le cours est gangrené par les habitudes de développeur Java de l'auteur. Certains concepts essentiels dans le développement Python sont complètements omis comme les dictionnaires, les sets, les générateurs ou la bibliothèque standard. Certains sont approximatifs comme les conditions ou les boucles. Les derniers introduisent des concepts qui vont à l'encontre des bonnes pratiques de développement en Python comme les fonctions ou les objets.
+Le cours est gangrené par les habitudes de développeur Java de l'auteur. Certains concepts essentiels dans le
+développement Python sont complètements omis comme les dictionnaires, les sets, les générateurs ou la bibliothèque
+standard. Certains sont approximatifs comme les conditions ou les boucles. Les derniers introduisent des concepts qui
+vont à l'encontre des bonnes pratiques de développement en Python comme les fonctions ou les objets.
 
 Graven est certainement un très bon développeur Java !

--- a/langages/python/index.md
+++ b/langages/python/index.md
@@ -1,0 +1,7 @@
+## Index
+
+### 2021
+
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>

--- a/langages/python/programmer-en-python-quel-ide-choisir.md
+++ b/langages/python/programmer-en-python-quel-ide-choisir.md
@@ -1,18 +1,30 @@
 # Programmer en Python, quel IDE choisir
 
-Python est un langage suffisamment simple pour qu'un IDE complet ne soit pas *nécessaire* à avoir une bonne vélocité de développement. Contrairement aux langages à la syntaxe plus lourde, il n'est pas forcément nécessaire d'avoir toute une série de patterns automatiquement générés par l'éditeur.
+Python est un langage suffisamment simple pour qu'un IDE complet ne soit pas *nécessaire* à avoir une bonne vélocité de
+développement. Contrairement aux langages à la syntaxe plus lourde, il n'est pas forcément nécessaire d'avoir toute une
+série de patterns automatiquement générés par l'éditeur.
 
-Python a un système de module léger : contrairement à Java où une classe = un fichier, il n'est pas rare d'avoir toute une série de classes liées définies au sein d'un même module. Ceci limite drastiquement la quantité d'`import` nécessaires en début de fichier et extensiblement la nécessité d'avoir ces lignes d'`import` faites automatiquement.
+Python a un système de module léger : contrairement à Java où une classe = un fichier, il n'est pas rare d'avoir toute
+une série de classes liées définies au sein d'un même module. Ceci limite drastiquement la quantité d'`import`
+nécessaires en début de fichier et extensiblement la nécessité d'avoir ces lignes d'`import` faites automatiquement.
 
-Python propose nativement un environnement REPL (Read-Eval-Print-Loop) via le terminal ou IDLE. Il est donc aisé de tester un bout de code, d'accéder à la documentation au moyen de la fonction `help` ou de lister l'ensemble des méthodes/fonctions d'une classe ou d'un module via la fonction `dir`. Personnellement je trouve qu'il est tout aussi rapide d'ouvrir l'interpréteur et de taper `dir(list)` suivi de `help(list.extend)` que d'utiliser la documentation fournie par un IDE ou de laisser l'autocomplétion me faire des suggestions.
+Python propose nativement un environnement REPL (Read-Eval-Print-Loop) via le terminal ou IDLE. Il est donc aisé de
+tester un bout de code, d'accéder à la documentation au moyen de la fonction `help` ou de lister l'ensemble des
+méthodes/fonctions d'une classe ou d'un module via la fonction `dir`. Personnellement je trouve qu'il est tout aussi
+rapide d'ouvrir l'interpréteur et de taper `dir(list)` suivi de `help(list.extend)` que d'utiliser la documentation
+fournie par un IDE ou de laisser l'autocomplétion me faire des suggestions.
 
-Python est dynamiquement typé. Bien qu'il existe des outils comme [mypy](http://mypy-lang.org) qui peuvent aider à la vérification des types, peu de modules tirent avantage de la bibliothèque `typing` et un IDE se retrouve fort peu utile pour lever des warning en cas d'incohérence de types.
+Python est dynamiquement typé. Bien qu'il existe des outils comme [mypy](http://mypy-lang.org) qui peuvent aider à la
+vérification des types, peu de modules tirent avantage de la bibliothèque `typing` et un IDE se retrouve fort peu utile
+pour lever des warning en cas d'incohérence de types.
 
-Tout ceci explique pourquoi un IDE n'est pas *nécessaire* au développement en Python. Un éditeur de texte plus léger reste un choix tout aussi viable.
+Tout ceci explique pourquoi un IDE n'est pas *nécessaire* au développement en Python. Un éditeur de texte plus léger
+reste un choix tout aussi viable.
 
 ## Mais donc quel IDE ?
 
-Au final il n'y pas d'éditeur qui se démarque particulièrement des autres. Il s'agit surtout d'en choisir un et se l'approprier.
+Au final il n'y pas d'éditeur qui se démarque particulièrement des autres. Il s'agit surtout d'en choisir un et se
+l'approprier.
 
 La liste suivante présente une liste non exhaustive :
 


### PR DESCRIPTION
Currently there is no index anywhere in the site, reaching for any
folder results in a 404 not found page. We suggested multiple times to
write an index.md file that just listes the articles present in the
folder of the same index.md file.

This utility is a python3 script that automaticall discover markdown
articles, gather metadata and update (or create) an index.md file at
the root of every folder.

This PR also fixes some broken links, enforce a 120 chars word
wrap (120 is the width of the github editor) for my python articles.

See also prior work: #8