### PR TITLE
fix: tag rendering in index

### DIFF
--- a/index.py
+++ b/index.py
@@ -230,7 +230,7 @@ def rewrite_index_file(dir_, articles):
                     title=article.title,
                     uri=article.uri_for_root(f'/{dir_}'.rstrip('/')),
                     tags=' '.join(
-                        f"<kbd>[{tag}]({uri})</kbd>"
+                        f"[<kbd>{tag}</kbd>]({uri})"
                         for tag, uri in article.tags
                     )
                 )


### PR DESCRIPTION
The code was rendering `<kbd>[tag][/tag/index.md</kbd>` instead of
`<kbd><a href=...>...</a></kbd>`. This fixes the html generation of
jekyll by inverting <a> and <kbd>.