### PR TITLE
meta: fix erronous symlink resolution in indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Not a Hub
+
+<https://hub.notaname.fr>
+
+## Comment contribuer
+
+Tous les contributeurs sont priés de respecter les règles de NaN qui sont
+disponibles sur notre serveur Discord.
+
+Vous pouvez contribuer selon le flux classique: fork, nouvelle branche,
+commit, pull-request. Les articles doivent être rédigé en français. Les
+messages de commit ainsi que l'activité sur GitHub peuvent être fait ou
+en français ou en anglais.
+
+Vous êtes prié de suivre notre convention concernant les messages de
+commits. Chaque message doit commencer par un titre séparé du reste du
+commit par une ligne vide. Le titre doit de préférence ne pas dépasser 50
+caractères et doit commencer par l'un des tags suivant: `add: ` pour
+l'ajout d'un nouvel article, `edit: ` pour la modification du contenu
+sémantique d'un article, `fix: ` pour une correction orthographique ou
+grammaticale, `meta: ` pour tout ce qui ne touche pas un article.
+
+Lorsque vous ajoutez un article ou renommer un article sur disque, pensez
+à exécuter l'indexer automatique: `python3 index.py` à la racine du repo,
+si vous avez peur d'oublier, vous pouvez le définir comme pre-commit-hook:
+
+	ln -s ../../index.py .git/hooks/pre-commit

--- a/game-dev/index.md
+++ b/game-dev/index.md
@@ -2,4 +2,4 @@
 
 ### 2021
 
-* [Ressources pour game-dev](/game-dev/ressources.md) <kbd>[game-dev](/game-dev)</kbd>
+* [Ressources pour game-dev](/game-dev/ressources.md) [<kbd>game-dev</kbd>](/game-dev)

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 ### 2021
 
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Ressources pour game-dev](/game-dev/ressources.md) <kbd>[game-dev](/game-dev)</kbd>
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Ressources pour game-dev](/game-dev/ressources.md) [<kbd>game-dev</kbd>](/game-dev)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/index.py
+++ b/index.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import List
 
 
-ROOT = Path(__file__).parent.resolve()
+ROOT = Path(__file__).resolve().parent
 GIT_PATH = getenv('GIT_PATH', '/usr/bin/git')
 SKIP_FILES = {'index.md', 'README.md'}
 

--- a/langages/index.md
+++ b/langages/index.md
@@ -2,6 +2,6 @@
 
 ### 2021
 
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/langages/python/index.md
+++ b/langages/python/index.md
@@ -2,6 +2,6 @@
 
 ### 2021
 
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) <kbd>[langages](/langages)</kbd> <kbd>[python](/langages/python)</kbd>
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)


### PR DESCRIPTION
Taking the parent of the current file returns the directory where the
symlink is defined if the file is a symlink. In case we symlink
`.git/hook/pre-commit` to `../../index.py` then the resolved parent was
`.git/hook` which was wrong.