### PR TITLE
meta: Change title to display the blog name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 theme: jekyll-theme-cayman
 
+title: Not a Hub
 lang: fr

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,8 +2,8 @@
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
     <meta charset="UTF-8">
+    <title>{{ page.title }} | {{ site.title }}</title>
 
-{% seo %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -13,8 +13,8 @@
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
-      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+      <h1 class="project-name">{{ site.title }}</h1>
+      <h2 class="project-tagline">{{ page.description }}</h2>
       {% if site.github.is_project_page %}
         <a href="/" class="btn">Aller à l'index</a>
         <a href="{{ site.github.repository_url }}" class="btn">Voir sur GitHub</a>


### PR DESCRIPTION
I just realized that the name of the blog was not written anywhere so I added them in the navigation bar and in the title tag.
I have also removed the %seo% tag to avoid duplicated title tag, I will open another PR later to add custom opengraph properties.