### PR TITLE
référencement articles

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://hub.notaname.fr/sitemap.txt

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,0 +1,9 @@
+https://hub.notaname.fr/game-dev/ressources
+https://hub.notaname.fr/langages/c/debunk-c
+https://hub.notaname.fr/langages/python/apprendre-python-quoi-lire-quoi-regarder
+https://hub.notaname.fr/langages/python/critique-du-cours-video-sur-python-de-graven
+https://hub.notaname.fr/langages/python/programmer-en-python-quel-ide-choisir
+https://hub.notaname.fr/langages/python/relatif-vs-absolu-demystifions-les-imports-python
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-booleens-et-conditions
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-prerequis
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-types-et-variables


### PR DESCRIPTION
J'ai ajouté un sitemap pour pouvoir permettre d'indexer plus de pages à google:

J'ai suivi ce lien: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap?hl=fr#addsitemap

Parce que comme vous pouvez le voir ici en copiant collant ça "site:https://hub.notaname.fr" (sans les guillemets) sur la barre de recherche de votre navigateur seulement deux pages sont indexées sur google.

J'ai aussi fait en sorte d'empêcher le script index.py d'ajouter le lien des articles une seconde fois
https://github.com/NotANameServer/Not-a-Hub/compare/master...luc-git:Not-a-Hub:sitemap?expand=1#diff-d568ca4e7eadfe7422397de0ed9269419d690f632aeb3e13826faefc79826ec9R134

Le soucis étant que si vous utilisez le script en local il va automatiquement chercher dans le sous dossier "_site".