### PR TITLE
Lazor/sitemap

### DIFF
--- a/game-dev/index.md
+++ b/game-dev/index.md
@@ -2,4 +2,4 @@
 
 ### 2021
 
-* [Ressources pour game-dev](/game-dev/ressources.md) [<kbd>game-dev</kbd>](/game-dev)
+* [Ressources pour game-dev](/game-dev/ressources) [<kbd>game-dev</kbd>](/game-dev)

--- a/index.md
+++ b/index.md
@@ -3,18 +3,18 @@
 ### 2023
 
 * [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2022
 
 * [Les idées reçues sur C](/langages/c/debunk-c) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
 * [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 * [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 * [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
 * [Ressources pour game-dev](/game-dev/ressources) [<kbd>game-dev</kbd>](/game-dev)
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 * [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/index.md
+++ b/index.md
@@ -2,19 +2,19 @@
 
 ### 2023
 
-* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2022
 
-* [Les idées reçues sur C](/langages/c/debunk-c.md) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
-* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Les idées reçues sur C](/langages/c/debunk-c) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
+* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
-* [Ressources pour game-dev](/game-dev/ressources.md) [<kbd>game-dev</kbd>](/game-dev)
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Ressources pour game-dev](/game-dev/ressources) [<kbd>game-dev</kbd>](/game-dev)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/index.py
+++ b/index.py
@@ -134,6 +134,8 @@ def discover_articles(root):
 
     articles = {}
     for path in root.glob('**/*.md'):
+        if '_site' in path.parts:  # jekyll generated files
+            continue
         if path.name in SKIP_FILES:
             continue
 

--- a/index.py
+++ b/index.py
@@ -51,8 +51,11 @@ class Article:
     @property
     def uris(self):
         # [/srv/git/Not-a-hub/langages/cpp/foo.md]
-        # => ["/langages/cpp/foo.md"]]
-        return [str(path)[len(str(ROOT)):].replace(sep, '/') for path in self.paths]
+        # => ["/langages/cpp/foo"]]
+        return [
+            str(path)[len(str(ROOT)):].replace(sep, '/').removesuffix('.md')
+            for path in self.paths
+        ]
 
     @property
     def tags(self):

--- a/index.py
+++ b/index.py
@@ -10,6 +10,7 @@ that title is missing).
 import dataclasses
 import itertools
 import subprocess as sp
+import urllib.parse
 from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime
@@ -24,6 +25,7 @@ from typing import List
 ROOT = Path(__file__).resolve().parent
 GIT_PATH = getenv('GIT_PATH', which('git'))
 SKIP_FILES = {'index.md', 'README.md', 'CONTRIBUTING.md'}
+DOMAIN = 'https://hub.notaname.fr/'
 
 
 def Tree():
@@ -151,6 +153,15 @@ def discover_articles(root):
     return list(articles.values())
 
 
+def update_sitemap(articles):
+    with open(ROOT / 'sitemap.txt', 'w') as sitemap_file:
+        sitemap_file.write(''.join(sorted([
+            urllib.parse.urljoin(DOMAIN, uri) + '\n'
+            for article in articles
+            for uri in article.uris
+        ])))
+
+
 def create_index(articles):
     """
     Populate an index, a filesystem-like structure where directories are
@@ -247,6 +258,7 @@ def rewrite_index_file(dir_, articles):
 def main():
     """ Rewrite all index files """
     articles = discover_articles(ROOT)
+    update_sitemap(articles)
     index = create_index(articles)
     walk('', index, rewrite=True)
 

--- a/langages/c/index.md
+++ b/langages/c/index.md
@@ -2,4 +2,4 @@
 
 ### 2022
 
-* [Les idées reçues sur C](/langages/c/debunk-c.md) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
+* [Les idées reçues sur C](/langages/c/debunk-c) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)

--- a/langages/index.md
+++ b/langages/index.md
@@ -3,17 +3,17 @@
 ### 2023
 
 * [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2022
 
 * [Les idées reçues sur C](/langages/c/debunk-c) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
 * [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 * [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 * [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 * [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/langages/index.md
+++ b/langages/index.md
@@ -2,18 +2,18 @@
 
 ### 2023
 
-* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2022
 
-* [Les idées reçues sur C](/langages/c/debunk-c.md) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
-* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Les idées reçues sur C](/langages/c/debunk-c) [<kbd>c</kbd>](/langages/c) [<kbd>langages</kbd>](/langages)
+* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/langages/python/index.md
+++ b/langages/python/index.md
@@ -1,14 +1,11 @@
 ## Index
 
-### 2023
-
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-
 ### 2022
 
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 * [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 * [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/langages/python/index.md
+++ b/langages/python/index.md
@@ -1,11 +1,14 @@
 ## Index
 
+### 2023
+
+* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+
 ### 2022
 
-* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Programmer en Python, quel IDE choisir](/langages/python/programmer-en-python-quel-ide-choisir.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Relatif vs Absolu, démystifions les imports python](/langages/python/relatif-vs-absolu-demystifions-les-imports-python) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
 
 ### 2021
 
-* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
-* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder.md) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Critique du cours vidéo sur Python de Graven](/langages/python/critique-du-cours-video-sur-python-de-graven) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)
+* [Apprendre Python, quoi lire, quoi regarder](/langages/python/apprendre-python-quoi-lire-quoi-regarder) [<kbd>langages</kbd>](/langages) [<kbd>python</kbd>](/langages/python)

--- a/langages/scala/index.md
+++ b/langages/scala/index.md
@@ -2,10 +2,10 @@
 
 ### 2023
 
-* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 
 ### 2022
 
-* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables.md) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)

--- a/langages/scala/index.md
+++ b/langages/scala/index.md
@@ -3,9 +3,9 @@
 ### 2023
 
 * [Scala comme premier langage de programmation](/langages/scala/scala-comme-premier-langage) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
-* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 
 ### 2022
 
 * [Programmer en Scala 3 : Booléens et conditions](/langages/scala/programmer-en-scala-3-booleens-et-conditions) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
+* [Programmer en Scala 3 : Types et Variables](/langages/scala/programmer-en-scala-3-types-et-variables) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)
 * [Programmer en Scala 3 : Les prérequis](/langages/scala/programmer-en-scala-3-prerequis) [<kbd>langages</kbd>](/langages) [<kbd>scala</kbd>](/langages/scala)

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://hub.notaname.fr/sitemap.txt

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,0 +1,10 @@
+https://hub.notaname.fr/game-dev/ressources
+https://hub.notaname.fr/langages/c/debunk-c
+https://hub.notaname.fr/langages/python/apprendre-python-quoi-lire-quoi-regarder
+https://hub.notaname.fr/langages/python/critique-du-cours-video-sur-python-de-graven
+https://hub.notaname.fr/langages/python/programmer-en-python-quel-ide-choisir
+https://hub.notaname.fr/langages/python/relatif-vs-absolu-demystifions-les-imports-python
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-booleens-et-conditions
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-prerequis
+https://hub.notaname.fr/langages/scala/programmer-en-scala-3-types-et-variables
+https://hub.notaname.fr/langages/scala/scala-comme-premier-langage


### PR DESCRIPTION
There are 2 fixes and a new feature


**meta(index): don't index jekyll copied files**

When one generate the site locally using jekyll, the tool copies all .md files into the generated site (under the `_site` folder). We don't want the indexer to index those files.

**meta(index): link to HTML page instead of MD file**

When one access a .md file via one of the index, jekyll makes the browser download the file instead of rendering the HTML page. Dropping the extension makes in the generated links makes jekyll render the HTML page instead which is the desired behavior.

**meta: new sitemap for better SEO**

Various search engine attempt to access a "sitemap" file stored at the project root to discover all URIs accessible on a website.

Closes: #46

