### PR TITLE
meta: ajout du titre du site pour google

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,19 @@
 
 	{% include opengraph.html %}
 
+	{% if page.url == "/" %}
+		<script type="application/ld+json">
+		{
+		  "@context" : "https://schema.org",
+		  "@type" : "WebSite",
+		  "name" : "Not a Hub",
+		  "alternateName" : "Not-a-Hub",
+		  "url" : "{{site.url}}"
+		}
+		</script>
+	
+	{% endif %}
+
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="theme-color" content="#157878">
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Le nom du site n'est pas correct sur google c'est noté comme "notaname.fr".
Donc j'essaye de corriger à l'aide de ça https://developers.google.com/search/docs/appearance/site-names?hl=fr#website.
C'est étrange google supporte opengraph normalement. Même pour la description ça marche pas.