### PR TITLE
Edit py-proj git init + do not upload

### DIFF
--- a/langages/python/comment-structurer-un-projet-python.md
+++ b/langages/python/comment-structurer-un-projet-python.md
@@ -74,6 +74,8 @@ Au terme de cette étape, votre projet devrait ressembler à ceci:
       LICENSE.txt
       README.md
 
+Si vous utilisez un logiciel de contrôle de version (comme *git*), vous pouvez d'ores et déjà initialiser votre logiciel avec les fichiers existants. Les utilisateurs de *git* peuvent donc taper la commande `git init` en étant à l'intérieur de la racine du projet, c'est-à-dire à l'intérieur du premier dossier `tartempion`.
+
 ### Lancement du projet
 
 Pour vérifier que cette structure minimale fonctionne correctement, vous pouvez écrire ceci dans le fichier `__init__.py` :

--- a/langages/python/comment-structurer-un-projet-python.md
+++ b/langages/python/comment-structurer-un-projet-python.md
@@ -359,6 +359,10 @@ authors = [
     { name = "Bob", email = "bob@example.com" },
 ]
 
+classifiers = [
+  "Private :: Do Not Upload",
+]
+
 # Exemple de dépendances
 dependencies = [
     "pygame",
@@ -377,6 +381,8 @@ La première partie du fichier, `[project]`, défini l'ensemble des méta-donné
 **Important**, le champ `name` dans ce fichier n'est pas obligatoirement le même que le nom de votre dossier. Il est d'ailleurs conseillé d'ajouter votre pseudo ou un autre élément unique à la fin pour vous assurer qu'il sera unique sur internet. Dans cet exemple nous avons ajouté `_NaN` pour "Not a Name", ce blog.
 
 Contrairement à une croyance populaire, reprise par beaucoup de tutoriels erronés en ligne, les dépendances sont bien à inscrire dans le champ `dependencies` du `pyproject.toml` et non pas dans un fichier `requirements.txt`. Vous pouvez lire la discussion [install_requires vs requirements files] dans la documentation officielle pour en apprendre plus.
+
+La liste associée au champ `classfiers` permet de catégoriser votre logiciel en fonction de l'audience visée, le sujet générale de votre logiciel et d'autres informations. Ce champ n'est pas essentiel. Si vous comptez héberger votre logiciel sur <pypi.org>, vous devrez retirer la ligne `"Private :: Do Not Upload",`.
 
 La seconde partie du fichier, `[build-system]`, décrit quels outils seront utilisés pour créer les archives pour votre projet. Cette partie est obligatoire mais vous pouvez vous contenter de garder celle de l'exemple.
 


### PR DESCRIPTION
**edit: prevent uploading sample py project to pypi**

Formally defining a python project is done via the `pyproject.toml`
file. The usage of that file is also required to upload a project to
<pypi.org>. I want to prevent noobs from polluting the internet with
their bad projects, I rather they send wheel files to their friend via
other means. I added the `Do Not Upload` classifier so that by default
<pypi.org> will reject their project, muhahaha.

---

**edit: explain where to git init in py-project**

---

Fixes: #62
