### PR TITLE
meta: update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/autre-chose-quun-article.yaml
+++ b/.github/ISSUE_TEMPLATE/autre-chose-quun-article.yaml
@@ -1,4 +1,4 @@
 name: Autre chose qu'un article
 description: Ouvrir une discussion sur l'organisation, le blog en général ou les outils qui gravitent autours
-title: '[META] '
-labels: ['meta']
+title: ''
+labels: ['Meta']

--- a/.github/ISSUE_TEMPLATE/corriger-un-article.yaml
+++ b/.github/ISSUE_TEMPLATE/corriger-un-article.yaml
@@ -1,7 +1,7 @@
-name: Commenter un article
-description: Poser une question à propos d'un article
+name: Corriger un article
+description: Apporter une correction ou une précision à propos d'un article
 title: ''
-labels: ['Question']
+labels: ['Amélioration']
 body:
   - type: input
     id: url-article
@@ -12,6 +12,6 @@ body:
   - type: textarea
     attributes:
       label: À propos de cet article
-      description: 'Écrivez votre question ci-dessous'
+      description: 'Écrivez ce que vous souhaiteriez modifier ci-dessous'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/proposer-un-article.yaml
+++ b/.github/ISSUE_TEMPLATE/proposer-un-article.yaml
@@ -1,7 +1,7 @@
 name: Proposer un article
 description: Proposer un nouvel article pour le blog
-title: '[NOUVEL ARTICLE] '
-labels: ['article']
+title: ''
+labels: ['Nouvel article']
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/suggestion-de-ressource-de-gamedev.yaml
+++ b/.github/ISSUE_TEMPLATE/suggestion-de-ressource-de-gamedev.yaml
@@ -1,7 +1,7 @@
 name: Suggestion de ressource de gamedev
 description: Ajout d'une ressource a la page "Ressources pour game-dev"
-title: '[GAMEDEV RESOURCES] '
-labels: ['gamedev-resources']
+title: ''
+labels: ['Gamedev resources']
 body:
   - type: input
     id: nom


### PR DESCRIPTION
- templates has been updated to avoid inserting [label] in the title. Also, new labels are used now.
- a new template corriger-un-article.yaml has been created
- a badly named template autre-chose-quun-article has been fixed